### PR TITLE
Updated BroadcastListener to set port for reuse

### DIFF
--- a/src/main/java/org/timothyb89/lifx/net/BroadcastListener.java
+++ b/src/main/java/org/timothyb89/lifx/net/BroadcastListener.java
@@ -91,8 +91,10 @@ public class BroadcastListener implements EventBusProvider {
 		}
 		
 		channel = DatagramChannel.open();
-		channel.socket().bind(new InetSocketAddress(BROADCAST_PORT));
-		channel.socket().setBroadcast(true);
+		DatagramSocket socket = channel.socket();
+		socket.setReuseAddress(true);
+		socket.bind(new InetSocketAddress(BROADCAST_PORT));
+		socket.setBroadcast(true);
 		channel.configureBlocking(true);
 		
 		listenerThread = new Thread(listener, "lifx-udp-listen");


### PR DESCRIPTION
The original code was impacting Android users. If multiple apps using this code were open then only the first app would be able to connect to the socket. The new code allows the socket to be shared.

This could be parameterized, but I think the default should be to set the socket for reuse.